### PR TITLE
Fix no AAR file in built artifacts

### DIFF
--- a/QRGenearator/build.gradle
+++ b/QRGenearator/build.gradle
@@ -14,6 +14,12 @@ android {
         }
     }
     namespace 'androidmads.library.qrgenearator'
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -21,12 +27,15 @@ dependencies {
     implementation 'com.google.zxing:android-integration:3.3.0'
 }
 
-publishing {
-    publications {
-        release(MavenPublication) {
-//            afterEvaluate {
-//                from components.release
-//            }
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+                groupId = 'com.github.androidmads'
+                artifactId = 'QRGenearator'
+                version = '1.0.4'
+            }
         }
     }
 }


### PR DESCRIPTION
Current logs:
https://jitpack.io/com/github/androidmads/QRGenerator/1.0.4/build.log
```
Files: 
com/github/androidmads/QRGenerator/1.0.4
com/github/androidmads/QRGenerator/1.0.4/QRGenerator-1.0.4-sources.jar
com/github/androidmads/QRGenerator/1.0.4/QRGenerator-1.0.4.pom
com/github/androidmads/QRGenerator/1.0.4/QRGenerator-1.0.4.pom.md5
com/github/androidmads/QRGenerator/1.0.4/QRGenerator-1.0.4.pom.sha1
com/github/androidmads/QRGenerator/1.0.4/build.log
```

After edited logs:
https://jitpack.io/com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/build.log
```
Files: 
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/QRGenerator-fix_no_aar_file-efccc6f5fb-1-sources.jar
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/QRGenerator-fix_no_aar_file-efccc6f5fb-1.aar <--- this file
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/QRGenerator-fix_no_aar_file-efccc6f5fb-1.module
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/QRGenerator-fix_no_aar_file-efccc6f5fb-1.pom
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/QRGenerator-fix_no_aar_file-efccc6f5fb-1.pom.md5
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/QRGenerator-fix_no_aar_file-efccc6f5fb-1.pom.sha1
com/github/phucynwa/QRGenerator/fix_no_aar_file-efccc6f5fb-1/build.log
```