### PR TITLE
Fix duplicate class error

### DIFF
--- a/QRGenearator/build.gradle
+++ b/QRGenearator/build.gradle
@@ -24,7 +24,6 @@ android {
 
 dependencies {
     implementation 'com.google.zxing:core:3.5.0'
-    implementation 'com.google.zxing:android-integration:3.3.0'
 }
 
 afterEvaluate {


### PR DESCRIPTION
In the previous code, when I build my project, the IDE show error:
```
Duplicate class com.google.zxing.integration.android.IntentIntegrator found in modules android-integration-3.3.0.jar -> android-integration-3.3.0 (com.google.zxing:android-integration:3.3.0) and zxing-android-embedded-4.3.0.aar -> zxing-android-embedded-4.3.0-runtime (com.journeyapps:zxing-android-embedded:4.3.0)
Duplicate class com.google.zxing.integration.android.IntentResult found in modules android-integration-3.3.0.jar -> android-integration-3.3.0 (com.google.zxing:android-integration:3.3.0) and zxing-android-embedded-4.3.0.aar -> zxing-android-embedded-4.3.0-runtime (com.journeyapps:zxing-android-embedded:4.3.0)
```

After researching, I realize that it can be fixed by just removing `implementation 'com.google.zxing:android-integration:3.3.0'`, this dependency is uneccessary and too outdated (last update since 2016).

Now it works like a charm. 😊 

You can try my jitpack build: implementation("com.github.phucynwa:QRGenerator:fix_duplicate_class-SNAPSHOT")
